### PR TITLE
Allow direct home access

### DIFF
--- a/io.github.suchnsuch.Tangent.yaml
+++ b/io.github.suchnsuch.Tangent.yaml
@@ -15,6 +15,7 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --share=network
+  - --filesystem=home
 
 modules:
   - name: tangent


### PR DESCRIPTION
For some reason the application doesn't like being run on some distributions (so far reproduced on Debian an Pop!_OS). Allowing access to the home directory fixes it.

Not ideal but avoids users getting a broken application upon installation.

See https://github.com/suchnsuch/Tangent/issues/134.